### PR TITLE
added 'timer' to the list of enabled callbacks in ansible.cfg

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,7 +1,7 @@
 [defaults]
 action_warnings = false
 collections_on_ansible_version_mismatch = warning
-callbacks_enabled = profile_tasks
+callbacks_enabled = profile_tasks, timer
 show_custom_stats = true
 #inject_facts_as_vars = no
 deprecation_warnings = false


### PR DESCRIPTION
The 'profile_tasks' callback will print a detailed breakdown of individual task execution times, sorted from longest to shortest, as well as a running timer for overall playbooks execution.

And 'timer' prints total execution time for the whole playbook from beginning to end.

Combined, these two are a great start to benchmarking playbook timing and performance.